### PR TITLE
PP-9940: No-op change for post-merge workflow run

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -22,4 +22,3 @@ jobs:
     permissions:
       contents: write
     uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@master
-


### PR DESCRIPTION
The post-merge workflow didn't have the checkout action approved and you can't re-run workflows that fail so early in the run.

This no-op change will force the workflow to run again.