### PR TITLE
PP-9940: No-op change for post-merge workflow run 2

### DIFF
--- a/govuk-tests/README.md
+++ b/govuk-tests/README.md
@@ -5,3 +5,4 @@ The tests in this directory are only to validate the built container image can s
 We are deviating from the official grafana/carbon-relay-ng docker image, so we are explicitly testing our changes and trusting the upstream build and test otherwise.
 
 To run the tests you first need to build carbon-relay-ng, and then you can run the `run-tests.sh` script.
+


### PR DESCRIPTION
The previous change (https://github.com/alphagov/carbon-relay-ng/pull/3) was in .github which is specifically ignored by the post-merge workflow.

Trigger the post-merge workflow.