### PR TITLE
BAU: Update go 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
   test:
     working_directory: /home/circleci/go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.20.3
     steps:
       - checkout
       - run: make test
@@ -75,7 +75,7 @@ jobs:
   build:
     working_directory: /home/circleci/go/src/github.com/grafana/carbon-relay-ng
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.20.4
     steps:
       - checkout
       - run: go install github.com/go-bindata/go-bindata/...@latest
@@ -166,7 +166,7 @@ jobs:
 
   github_binaries:
       docker:
-        - image: cimg/go:1.18
+        - image: cimg/go:1.20.4
       steps:
         - checkout
         - run: curl -sfL https://goreleaser.com/static/run | bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # unreleased
 
+# v1.4.3: May 5, 2023
+* Bump go mod version to 1.20 and update go images used to build carbon-relay-ng to 1.20.4 #518
+
+# v1.4.2: April 19, 2023
+* Update go images used to build carbon-relay-ng to 1.20.3 #517
+
 # v1.4.1: March 9, 2023
 * Bump `golang.org/x/crypto` to 0.1.0 #514
 

--- a/go-whisper/whisper.go
+++ b/go-whisper/whisper.go
@@ -59,13 +59,13 @@ func parseRetentionPart(retentionPart string) (int, error) {
 }
 
 /*
-  Parse a retention definition as you would find in the storage-schemas.conf of a Carbon install.
-  Note that this only parses a single retention definition, if you have multiple definitions (separated by a comma)
-  you will have to split them yourself.
+Parse a retention definition as you would find in the storage-schemas.conf of a Carbon install.
+Note that this only parses a single retention definition, if you have multiple definitions (separated by a comma)
+you will have to split them yourself.
 
-  ParseRetentionDef("10s:14d") Retention{10, 120960}
+ParseRetentionDef("10s:14d") Retention{10, 120960}
 
-  See: http://graphite.readthedocs.org/en/1.0/config-carbon.html#storage-schemas-conf
+See: http://graphite.readthedocs.org/en/1.0/config-carbon.html#storage-schemas-conf
 */
 func ParseRetentionDef(retentionDef string) (*Retention, error) {
 	parts := strings.Split(retentionDef, ":")
@@ -128,10 +128,10 @@ func validateRetentions(retentions Retentions) error {
 }
 
 /*
-  A retention level.
+A retention level.
 
-  Retention levels describe a given archive in the database. How detailed it is and how far back
-  it records.
+Retention levels describe a given archive in the database. How detailed it is and how far back
+it records.
 */
 type Retention struct {
 	secondsPerPoint int
@@ -178,8 +178,8 @@ func (r retentionsByPrecision) Less(i, j int) bool {
 }
 
 /*
-   Implementation of modulo that works like Python
-   Thanks @timmow for this
+Implementation of modulo that works like Python
+Thanks @timmow for this
 */
 func mod(a, b int) int {
 	return a - (b * int(math.Floor(float64(a)/float64(b))))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/carbon-relay-ng
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go v0.18.1-0.20180119164648-b1067c1d21b5


### PR DESCRIPTION
Syncing this fork with the upstream repo ([grafana/carbon-relay-ng](https://github.com/grafana/carbon-relay-ng)), to bring the version of Go up to 1.20. 

[The previous update (to 1.18)](https://github.com/alphagov/carbon-relay-ng/pull/21) in March had to be manually cherry picked rather than syncing the commits. This time, for some reason `git merge upstream/master` actually worked (!) with only a couple of manual conflicts to fix 😸 So while it looks like a lot of commits added below, the Files Changed tab gives a better reviewing experience.

To keep things as close to the upstream fork as possible (aside from our own Dockerfile versioning and Github Actions config), I've left in their typo on the CircleCI test image version number, as we're not using it anywhere.

